### PR TITLE
Add support for options and buf-size features.

### DIFF
--- a/modules/jlv2_host/host/SymbolMap.h
+++ b/modules/jlv2_host/host/SymbolMap.h
@@ -167,7 +167,66 @@ private:
 
         friend class SymbolMap;
     };
+};
 
+class OptionsFeature :  public LV2Feature
+{
+public:
+    OptionsFeature (SymbolMap& symbolMap)
+    {
+        uri = LV2_OPTIONS__options;
+        feat.URI    = uri.toRawUTF8();
+        feat.data   = options;
+
+        minBlockLengthOption = LV2_Options_Option{LV2_OPTIONS_INSTANCE,
+                                0,
+                                symbolMap.map(LV2_BUF_SIZE__minBlockLength),
+                                sizeof(int),
+                                symbolMap.map(LV2_ATOM__Int),
+                                &minBlockLengthValue};
+        maxBlockLengthOption = LV2_Options_Option{LV2_OPTIONS_INSTANCE,
+                                0,
+                                symbolMap.map(LV2_BUF_SIZE__maxBlockLength),
+                                sizeof(int),
+                                symbolMap.map(LV2_ATOM__Int),
+                                &maxBlockLengthValue};
+        options[0] = minBlockLengthOption;
+        options[1] = maxBlockLengthOption;
+        options[2] = LV2_Options_Option{LV2_OPTIONS_BLANK, 0, 0, 0, 0};                        
+    }
+
+    virtual ~OptionsFeature() { }
+
+    LV2_Options_Option minBlockLengthOption, maxBlockLengthOption;
+    LV2_Options_Option options[3];
+    const int minBlockLengthValue = 128;
+    const int maxBlockLengthValue = 8192;
+    const String& getURI() const { return uri; }
+    const LV2_Feature* getFeature() const { return &feat; }
+
+private:
+    String       uri;
+    LV2_Feature  feat;
+    friend class SymbolMap;
+};
+
+class BoundedBlockLengthFeature : public LV2Feature
+{
+public:
+    BoundedBlockLengthFeature()
+    {
+        uri = LV2_BUF_SIZE__boundedBlockLength;
+        feat.URI = uri.toRawUTF8();
+        feat.data = nullptr;
+    }
+
+    virtual ~BoundedBlockLengthFeature() { }
+    const String& getURI() const { return uri; }
+    const LV2_Feature* getFeature() const { return &feat; }
+
+private:
+    String       uri;
+    LV2_Feature  feat;
 };
 
 }

--- a/modules/jlv2_host/host/World.cpp
+++ b/modules/jlv2_host/host/World.cpp
@@ -47,6 +47,7 @@ World::World()
     midi_MidiEvent  = lilv_new_uri (world, LV2_MIDI__MidiEvent);
     work_schedule   = lilv_new_uri (world, LV2_WORKER__schedule);
     work_interface  = lilv_new_uri (world, LV2_WORKER__interface);
+    options_options = lilv_new_uri (world, LV2_OPTIONS__options);
     ui_CocoaUI      = lilv_new_uri (world, LV2_UI__CocoaUI);
     ui_WindowsUI    = lilv_new_uri (world, LV2_UI__WindowsUI);
     ui_X11UI        = lilv_new_uri (world, LV2_UI__X11UI);
@@ -82,6 +83,8 @@ World::World()
     addFeature (symbolMap.createMapFeature(), false);
     addFeature (symbolMap.createUnmapFeature(), false);
     addFeature (new LogFeature(), true);
+    addFeature (new OptionsFeature(symbolMap), true);
+    addFeature (new BoundedBlockLengthFeature(), true);
 }
 
 World::~World()
@@ -97,6 +100,7 @@ World::~World()
     _node_free (midi_MidiEvent);
     _node_free (work_schedule);
     _node_free (work_interface);
+    _node_free (options_options);
     _node_free (ui_CocoaUI);
     _node_free (ui_WindowsUI);
     _node_free (ui_GtkUI);
@@ -211,6 +215,7 @@ bool World::isFeatureSupported (const String& featureURI) const
        featureURI == LV2_STATE__loadDefaultState)
       return true;
 
+   JUCE_LV2_LOG("warning: feature " + featureURI + " not supported.");
    return false;
 }
 

--- a/modules/jlv2_host/host/World.h
+++ b/modules/jlv2_host/host/World.h
@@ -52,6 +52,7 @@ public:
     const LilvNode*   midi_MidiEvent;
     const LilvNode*   work_schedule;
     const LilvNode*   work_interface;
+    const LilvNode*   options_options;
     const LilvNode*   ui_CocoaUI;
     const LilvNode*   ui_WindowsUI;
     const LilvNode*   ui_X11UI;

--- a/modules/jlv2_host/jlv2_host.cpp
+++ b/modules/jlv2_host/jlv2_host.cpp
@@ -34,11 +34,13 @@
 #include <lv2/lv2plug.in/ns/extensions/units/units.h>
 #include <lv2/lv2plug.in/ns/ext/atom/atom.h>
 #include <lv2/lv2plug.in/ns/ext/atom/util.h>
+#include <lv2/lv2plug.in/ns/ext/buf-size/buf-size.h>
 #include <lv2/lv2plug.in/ns/ext/data-access/data-access.h>
 #include <lv2/lv2plug.in/ns/ext/event/event.h>
 #include <lv2/lv2plug.in/ns/ext/instance-access/instance-access.h>
 #include <lv2/lv2plug.in/ns/ext/log/log.h>
 #include <lv2/lv2plug.in/ns/ext/midi/midi.h>
+#include <lv2/lv2plug.in/ns/ext/options/options.h>
 #include <lv2/lv2plug.in/ns/ext/state/state.h>
 #include <lv2/lv2plug.in/ns/ext/urid/urid.h>
 #include <lv2/lv2plug.in/ns/ext/uri-map/uri-map.h>


### PR DESCRIPTION
This brings in a bunch of LV2 plugins such as Dragonfly-Reverb, sfizz,
helm, string-machine, zynaddsubfx etc.

I have no idea what your ideal source file structuring is, so I'd leave it to you.

The patch is provided under the ISC License.