### PR TITLE
Error out if worker feature is null and an extension data is Worker interface.

### DIFF
--- a/modules/jlv2_host/host/Module.cpp
+++ b/modules/jlv2_host/host/Module.cpp
@@ -411,7 +411,8 @@ Result Module::instantiate (double samplerate)
 
     if (const void* data = getExtensionData (LV2_WORKER__interface))
     {
-        jassert (worker != nullptr);
+        if (worker == nullptr)
+            return Result::fail ("Could not get worker feature whereas extension data exists.");
         worker->setSize (2048);
         worker->setInterface (lilv_instance_get_handle (instance),
                               (LV2_Worker_Interface*) data);


### PR DESCRIPTION
Fix https://github.com/lvtk/jlv2/issues/3 , kind of.

When worker feature does not exist but Worker interface is specified as an
extension, the plugin lookup crashes. Avoid jassert and return as an error.